### PR TITLE
Back/backend media security hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ yarn-error.*
 # local env files
 .env*.local
 .env
+backend/.env.local
 backend/.env.staging
 backend/.env.prod
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,17 +1,13 @@
-# Copy this file to `.env.local` for local tests, or `.env.staging` for staging tests.
-# Local default:
-# SUPABASE_URL=http://127.0.0.1:54321
-# SUPABASE_ANON_KEY=<local-anon-key>
+# Base template for backend test environments.
+# Copy one of the dedicated templates below:
+# - backend/.env.local.example   -> backend/.env.local
+# - backend/.env.staging.example -> backend/.env.staging
+# - backend/.env.prod.example    -> backend/.env.prod
 #
-# Staging:
-# SUPABASE_URL=https://your-staging-project-ref.supabase.co
-# SUPABASE_ANON_KEY=<staging-anon-key>
-
+# Required variables:
 SUPABASE_URL=
 SUPABASE_ANON_KEY=
-
-OWNER_EMAIL=owner@imovia.test
+OWNER_EMAIL=
 OWNER_PASS=
-
-TENANT_EMAIL=tenant@imovia.test
+TENANT_EMAIL=
 TENANT_PASS=

--- a/backend/.env.local.example
+++ b/backend/.env.local.example
@@ -1,0 +1,8 @@
+SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=<local-anon-key>
+
+OWNER_EMAIL=owner@imovia.test
+OWNER_PASS=test
+
+TENANT_EMAIL=tenant@imovia.test
+TENANT_PASS=test

--- a/backend/.env.prod.example
+++ b/backend/.env.prod.example
@@ -1,0 +1,8 @@
+SUPABASE_URL=https://your-prod-project-ref.supabase.co
+SUPABASE_ANON_KEY=<prod-anon-key>
+
+OWNER_EMAIL=<prod-owner-email>
+OWNER_PASS=<prod-owner-password>
+
+TENANT_EMAIL=<prod-tenant-email>
+TENANT_PASS=<prod-tenant-password>

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -1,0 +1,8 @@
+SUPABASE_URL=https://your-staging-project-ref.supabase.co
+SUPABASE_ANON_KEY=<staging-anon-key>
+
+OWNER_EMAIL=owner@imovia.test
+OWNER_PASS=<staging-owner-password>
+
+TENANT_EMAIL=tenant@imovia.test
+TENANT_PASS=<staging-tenant-password>

--- a/backend/BACKEND_CONTRACT.md
+++ b/backend/BACKEND_CONTRACT.md
@@ -80,6 +80,7 @@ await supabase.rpc("get_owner_dashboard");
 Use normal `select` on:
 
 - `properties`
+- `property_images`
 - `leases`
 - `lease_tenants`
 - `rental_applications`
@@ -87,14 +88,19 @@ Use normal `select` on:
 - `incidents`
 - `maintenance_requests`
 - `documents`
+- `profiles`
 - `owner_kpis` (view)
 
 RLS decides visibility based on authenticated user ownership/membership.
 
-## Storage Contract (Documents)
+## Storage Contract
 
 - Bucket: `documents` (private)
-- Object path format: `leases/{leaseId}/{uuid}-{filename}`
+- Bucket: `property-images` (private)
+- Bucket: `avatars` (private)
+- Object path format (documents): `leases/{leaseId}/{uuid}-{filename}`
+- Object path format (property images): `properties/{propertyId}/{uuid}-{filename}`
+- Object path format (avatars): `profiles/{userId}/{uuid}-{filename}`
 
 Upload example:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -49,23 +49,35 @@ npm install
 
 ## Environment Variables
 
-Create `backend/.env.local` for local tests (copy from `backend/.env.example`):
+Create environment files from templates:
 
-```env
-SUPABASE_URL=http://127.0.0.1:54321
-SUPABASE_ANON_KEY=<local-anon-key>
-
-OWNER_EMAIL=owner@imovia.test
-OWNER_PASS=test
-
-TENANT_EMAIL=tenant@imovia.test
-TENANT_PASS=test
+```bash
+cp backend/.env.local.example backend/.env.local
+cp backend/.env.staging.example backend/.env.staging
+cp backend/.env.prod.example backend/.env.prod
 ```
 
-For staging, copy `backend/.env.example` to `backend/.env.staging` and set staging values.
+PowerShell:
+
+```powershell
+Copy-Item backend/.env.local.example backend/.env.local
+Copy-Item backend/.env.staging.example backend/.env.staging
+Copy-Item backend/.env.prod.example backend/.env.prod
+```
+
+Then fill each file values:
+- `backend/.env.local` -> local Supabase (`127.0.0.1`)
+- `backend/.env.staging` -> staging Supabase project
+- `backend/.env.prod` -> production Supabase project
+
+Reference templates:
+- `backend/.env.example` (base required keys)
+- `backend/.env.local.example`
+- `backend/.env.staging.example`
+- `backend/.env.prod.example`
 
 Security rules:
-- never commit real env files (`backend/.env.local`, `backend/.env.staging`, etc.)
+- never commit real env files (`backend/.env.local`, `backend/.env.staging`, `backend/.env.prod`)
 - never expose service role key in frontend apps
 
 ## Run Integration Test
@@ -82,9 +94,38 @@ Staging (explicit opt-in):
 TEST_TARGET=staging TEST_ENV_FILE=.env.staging ALLOW_REMOTE_TESTS=true node backend/test.mjs
 ```
 
+Staging (PowerShell):
+
+```powershell
+$env:TEST_TARGET="staging"
+$env:TEST_ENV_FILE=".env.staging"
+$env:ALLOW_REMOTE_TESTS="true"
+node backend/test.mjs
+```
+
+Production (dangerous, triple confirmation):
+
+```bash
+TEST_TARGET=prod TEST_ENV_FILE=.env.prod ALLOW_REMOTE_TESTS=true ALLOW_PROD_TESTS=true CONFIRM_PROD_HOST=<your-prod-host> node backend/test.mjs
+```
+
+Production (PowerShell):
+
+```powershell
+$env:TEST_TARGET="prod"
+$env:TEST_ENV_FILE=".env.prod"
+$env:ALLOW_REMOTE_TESTS="true"
+$env:ALLOW_PROD_TESTS="true"
+$env:CONFIRM_PROD_HOST="<your-prod-host>"
+node backend/test.mjs
+```
+
 Notes:
 - default mode is `TEST_TARGET=local` and expects `backend/.env.local`
 - script refuses remote writes unless `ALLOW_REMOTE_TESTS=true`
+- production mode also requires `ALLOW_PROD_TESTS=true` and `CONFIRM_PROD_HOST`
+- `TEST_TARGET`, `TEST_ENV_FILE`, `ALLOW_REMOTE_TESTS`, `ALLOW_PROD_TESTS`, and `CONFIRM_PROD_HOST` are terminal environment variables (not values hardcoded in the script)
+- `backend/.env` is legacy and not used by `backend/test.mjs`
 
 Expected success marker:
 
@@ -120,13 +161,17 @@ Frontend guidance:
 Contract source of truth:
 - `backend/BACKEND_CONTRACT.md` (current: `v1.0.0`)
 
-## Storage Contract (Documents)
+## Storage Contract
 
-Bucket:
+Buckets:
 - `documents` (private)
+- `property-images` (private)
+- `avatars` (private)
 
 Object key convention:
 - `leases/{leaseId}/{uuid}-{filename}`
+- `properties/{propertyId}/{uuid}-{filename}`
+- `profiles/{userId}/{uuid}-{filename}`
 
 Read/download:
 - use signed URLs (`createSignedUrl`)
@@ -239,7 +284,7 @@ Before merging to production branch:
 
 ## Troubleshooting
 
-- `Missing SUPABASE_URL or SUPABASE_ANON_KEY`: verify `backend/.env`.
+- `Missing SUPABASE_URL or SUPABASE_ANON_KEY`: verify the selected env file (`backend/.env.local`, `.env.staging`, or `.env.prod`).
 - `password authentication failed for user cli_login_postgres`: relink project and provide the correct DB password.
 - `Remote migration versions not found in local migrations directory`: run `supabase migration repair` then re-check migration list.
 - RLS rejection on documents/incidents/maintenance: verify lease membership and storage path convention.

--- a/backend/test.mjs
+++ b/backend/test.mjs
@@ -15,7 +15,7 @@ const envFile = process.env.TEST_ENV_FILE
 
 if (!fs.existsSync(envFile)) {
   throw new Error(
-    `Missing env file: ${envFile}. Copy backend/.env.example to .env.local (or .env.staging) and fill values.`
+    `Missing env file: ${envFile}. Copy backend/.env.local.example, .env.staging.example, or .env.prod.example and fill values.`
   );
 }
 
@@ -35,8 +35,8 @@ if (!ownerEmail || !ownerPass) throw new Error(`Missing OWNER_EMAIL/OWNER_PASS i
 if (!tenantEmail || !tenantPass) throw new Error(`Missing TENANT_EMAIL/TENANT_PASS in ${envFile}`);
 
 const testTarget = (process.env.TEST_TARGET || "local").toLowerCase();
-if (!["local", "staging"].includes(testTarget)) {
-  throw new Error(`Invalid TEST_TARGET="${testTarget}". Allowed values: local, staging`);
+if (!["local", "staging", "prod"].includes(testTarget)) {
+  throw new Error(`Invalid TEST_TARGET="${testTarget}". Allowed values: local, staging, prod`);
 }
 
 let host;
@@ -61,6 +61,29 @@ if (testTarget === "staging") {
   if (process.env.ALLOW_REMOTE_TESTS !== "true") {
     throw new Error(
       "Remote write protection: set ALLOW_REMOTE_TESTS=true to run against staging."
+    );
+  }
+}
+
+if (testTarget === "prod") {
+  if (isLocalHost) {
+    throw new Error("Prod test requires a remote Supabase URL, not localhost.");
+  }
+  if (process.env.ALLOW_REMOTE_TESTS !== "true") {
+    throw new Error(
+      "Remote write protection: set ALLOW_REMOTE_TESTS=true to run against prod."
+    );
+  }
+  if (process.env.ALLOW_PROD_TESTS !== "true") {
+    throw new Error(
+      "Production protection: set ALLOW_PROD_TESTS=true only if you intentionally run this on prod."
+    );
+  }
+
+  const confirmProdHost = (process.env.CONFIRM_PROD_HOST || "").toLowerCase();
+  if (!confirmProdHost || confirmProdHost !== host) {
+    throw new Error(
+      `Production confirmation required: set CONFIRM_PROD_HOST=${host} to continue.`
     );
   }
 }

--- a/supabase/migrations/20260218150000_media_storage_buckets.sql
+++ b/supabase/migrations/20260218150000_media_storage_buckets.sql
@@ -1,0 +1,195 @@
+begin;
+
+-- Media buckets for property images and profile avatars.
+insert into storage.buckets (id, name, public)
+values
+  ('documents', 'documents', false),
+  ('property-images', 'property-images', false),
+  ('avatars', 'avatars', false)
+on conflict (id) do update
+set
+  name = excluded.name,
+  public = excluded.public;
+
+-- Safe UUID extractors for storage object paths.
+create or replace function public.storage_property_id_from_path(p_path text)
+returns uuid
+language plpgsql
+stable
+set search_path = public, pg_catalog
+as $function$
+declare
+  v_part text;
+begin
+  v_part := nullif(split_part(p_path, '/', 2), '');
+  if v_part is null then
+    return null;
+  end if;
+
+  begin
+    return v_part::uuid;
+  exception when others then
+    return null;
+  end;
+end;
+$function$;
+
+create or replace function public.storage_user_id_from_path(p_path text)
+returns uuid
+language plpgsql
+stable
+set search_path = public, pg_catalog
+as $function$
+declare
+  v_part text;
+begin
+  v_part := nullif(split_part(p_path, '/', 2), '');
+  if v_part is null then
+    return null;
+  end if;
+
+  begin
+    return v_part::uuid;
+  exception when others then
+    return null;
+  end;
+end;
+$function$;
+
+-- Property images storage policies.
+drop policy if exists property_images_storage_insert on storage.objects;
+create policy property_images_storage_insert
+on storage.objects
+as permissive
+for insert
+to authenticated
+with check (
+  bucket_id = 'property-images'
+  and split_part(name, '/', 1) = 'properties'
+  and exists (
+    select 1
+    from public.properties p
+    where p.id = public.storage_property_id_from_path(name)
+      and p.owner_id = auth.uid()
+  )
+);
+
+drop policy if exists property_images_storage_read on storage.objects;
+create policy property_images_storage_read
+on storage.objects
+as permissive
+for select
+to public
+using (
+  bucket_id = 'property-images'
+  and split_part(name, '/', 1) = 'properties'
+  and exists (
+    select 1
+    from public.properties p
+    where p.id = public.storage_property_id_from_path(name)
+      and (
+        p.status = 'available'::public.property_status
+        or p.owner_id = public.current_user_id()
+      )
+  )
+);
+
+drop policy if exists property_images_storage_update on storage.objects;
+create policy property_images_storage_update
+on storage.objects
+as permissive
+for update
+to authenticated
+using (
+  bucket_id = 'property-images'
+  and split_part(name, '/', 1) = 'properties'
+  and exists (
+    select 1
+    from public.properties p
+    where p.id = public.storage_property_id_from_path(name)
+      and p.owner_id = auth.uid()
+  )
+)
+with check (
+  bucket_id = 'property-images'
+  and split_part(name, '/', 1) = 'properties'
+  and exists (
+    select 1
+    from public.properties p
+    where p.id = public.storage_property_id_from_path(name)
+      and p.owner_id = auth.uid()
+  )
+);
+
+drop policy if exists property_images_storage_delete on storage.objects;
+create policy property_images_storage_delete
+on storage.objects
+as permissive
+for delete
+to authenticated
+using (
+  bucket_id = 'property-images'
+  and split_part(name, '/', 1) = 'properties'
+  and exists (
+    select 1
+    from public.properties p
+    where p.id = public.storage_property_id_from_path(name)
+      and p.owner_id = auth.uid()
+  )
+);
+
+-- Avatar storage policies.
+drop policy if exists avatars_storage_insert on storage.objects;
+create policy avatars_storage_insert
+on storage.objects
+as permissive
+for insert
+to authenticated
+with check (
+  bucket_id = 'avatars'
+  and split_part(name, '/', 1) = 'profiles'
+  and public.storage_user_id_from_path(name) = auth.uid()
+);
+
+drop policy if exists avatars_storage_read on storage.objects;
+create policy avatars_storage_read
+on storage.objects
+as permissive
+for select
+to public
+using (
+  bucket_id = 'avatars'
+  and split_part(name, '/', 1) = 'profiles'
+  and public.storage_user_id_from_path(name) is not null
+);
+
+drop policy if exists avatars_storage_update on storage.objects;
+create policy avatars_storage_update
+on storage.objects
+as permissive
+for update
+to authenticated
+using (
+  bucket_id = 'avatars'
+  and split_part(name, '/', 1) = 'profiles'
+  and public.storage_user_id_from_path(name) = auth.uid()
+)
+with check (
+  bucket_id = 'avatars'
+  and split_part(name, '/', 1) = 'profiles'
+  and public.storage_user_id_from_path(name) = auth.uid()
+);
+
+drop policy if exists avatars_storage_delete on storage.objects;
+create policy avatars_storage_delete
+on storage.objects
+as permissive
+for delete
+to authenticated
+using (
+  bucket_id = 'avatars'
+  and split_part(name, '/', 1) = 'profiles'
+  and public.storage_user_id_from_path(name) = auth.uid()
+);
+
+commit;

--- a/supabase/migrations/20260218154000_security_advisor_fixes.sql
+++ b/supabase/migrations/20260218154000_security_advisor_fixes.sql
@@ -1,0 +1,28 @@
+begin;
+
+-- 1) Avoid SECURITY DEFINER view exposure warnings.
+alter view if exists public.owner_kpis set (security_invoker = true);
+alter view if exists public.owner_open_works set (security_invoker = true);
+alter view if exists public.owner_overdue_payments set (security_invoker = true);
+alter view if exists public.owner_open_incidents set (security_invoker = true);
+
+-- 2) Fix mutable search_path warnings on SQL helper functions.
+create or replace function public.current_user_id()
+returns uuid
+language sql
+stable
+set search_path = pg_catalog
+as $function$
+  select auth.uid()
+$function$;
+
+create or replace function public.storage_lease_id_from_path(p_path text)
+returns uuid
+language sql
+stable
+set search_path = pg_catalog
+as $function$
+  select nullif(split_part(p_path, '/', 2), '')::uuid
+$function$;
+
+commit;


### PR DESCRIPTION
## Summary
This PR finalizes backend hardening for multi-environment usage (local/staging/prod), adds media storage infrastructure, and fixes Supabase Security Advisor findings.

## What’s included

### 1) Safer backend test execution
- Updated `backend/test.mjs`:
  - supports `local`, `staging`, and `prod` targets
  - blocks accidental remote writes by default
  - adds explicit protection gates for production runs (`ALLOW_PROD_TESTS` + host confirmation)
- Clarified environment selection with `TEST_ENV_FILE`.

### 2) Environment templates cleanup
- Added:
  - `backend/.env.local.example`
  - `backend/.env.staging.example`
  - `backend/.env.prod.example`
- Standardized `backend/.env.example` as base template.
- Updated `.gitignore` for real env files.

### 3) Storage media migration
- Added migration:
  - `supabase/migrations/20260218150000_media_storage_buckets.sql`
- Creates/ensures buckets:
  - `documents`
  - `property-images`
  - `avatars`
- Adds path helper functions for storage object parsing.
- Adds storage policies for property images and profile avatars.

### 4) Security Advisor fixes
- Added migration:
  - `supabase/migrations/20260218154000_security_advisor_fixes.sql`
- Fixes:
  - SECURITY DEFINER view warnings (`owner_*` views -> `security_invoker = true`)
  - mutable search_path warnings for helper functions (`current_user_id`, `storage_lease_id_from_path`)

### 5) Documentation updates
- Updated:
  - `backend/README.md`
  - `backend/BACKEND_CONTRACT.md`
- Clarified storage contract, env setup, and run commands for local/staging/prod.

## Why
- Prevent accidental production mutations during integration tests.
- Make backend setup reproducible for all developers.
- Align staging/prod with migration-driven infrastructure.
- Reduce security findings before release.

## Validation
- `node --check backend/test.mjs` passes.
- Migrations are additive and ordered.
- Storage contract in docs now matches implemented buckets/policies.

## Notes
- This PR does not expose any secret keys.
- Leaked Password Protection must still be enabled via Supabase Dashboard (Auth settings), as it is not SQL-managed.
