### PR TITLE
feat(supabase): align DB with user flows and add agency legal profile model

### DIFF
--- a/backend/BACKEND_CONTRACT.md
+++ b/backend/BACKEND_CONTRACT.md
@@ -1,13 +1,13 @@
 # Backend Contract (Frontend Integration)
 
-Contract version: `v1.0.0`  
+Contract version: `v1.1.0`  
 Status: `stable`  
-Last updated: `2026-02-18`
+Last updated: `2026-02-20`
 This document is the practical contract for frontend developers using Supabase directly.
 
 ## Scope
 
-- Authenticated user flows for `owner` and `tenant`
+- Authenticated user flows for `owner`, `agency`, and `tenant`
 - Business writes through RPCs
 - Reads through RLS-protected tables/views
 - Private document storage access through signed URLs
@@ -15,8 +15,51 @@ This document is the practical contract for frontend developers using Supabase d
 ## Auth And Roles
 
 - All writes require an authenticated session.
-- Roles are stored in `public.profiles.role` (`tenant`, `owner`, `admin`).
+- Roles are stored in `public.profiles.role` (`tenant`, `owner`, `agency`, `admin`).
 - Client apps must not use the service role key.
+
+## Agency Profile Model
+
+Agency legal/business fields are stored in a dedicated table:
+- `public.agency_profiles` (one row per `profiles.id`)
+
+Read helper view:
+- `public.agency_account` (joins `profiles` + `agency_profiles` for agency users)
+
+Why this model:
+- keeps `profiles` clean for all roles
+- gives frontend a single place for agency-specific fields (`siret`, legal info, insurance, etc.)
+- enforces role/ownership in DB (RLS + trigger guard)
+
+Recommended write pattern (authenticated agency user):
+
+```ts
+await supabase
+  .from("agency_profiles")
+  .upsert(
+    {
+      profile_id: user.id,
+      agency_name: "Imovia Gestion",
+      siret: "12345678901234",
+      legal_form: "SAS",
+      business_email: "contact@imovia.fr",
+      business_phone: "+33 1 23 45 67 89",
+      professional_card_number: "CPI75012024000000000",
+    },
+    { onConflict: "profile_id" }
+  )
+  .select()
+  .single();
+```
+
+Recommended read pattern:
+
+```ts
+await supabase
+  .from("agency_account")
+  .select("*")
+  .single();
+```
 
 ## Write Contract (RPC First)
 
@@ -75,6 +118,37 @@ await supabase.rpc("get_owner_dashboard");
 - `create_maintenance_request`
 - `owner_update_incident_status`
 
+### `create_incident` (extended)
+
+Tenant declares an incident with optional typed metadata.
+
+```ts
+await supabase.rpc("create_incident", {
+  p_lease_id: "<lease-uuid>",
+  p_property_id: "<property-uuid>",
+  p_title: "Kitchen leak",
+  p_description: "Water leaking under the sink.",
+  p_incident_type: "plumbing", // optional, default: "other"
+  p_priority: "medium", // optional, default: "medium"
+  p_location_details: "Floor 1 - Kitchen", // optional
+  p_contact_phone: "+33 6 12 34 56 78", // optional
+  p_preferred_visit_date: "2026-03-04", // optional
+  p_allow_access_without_presence: false, // optional
+});
+```
+
+### `owner_update_incident_status` (extended)
+
+Owner/manager updates status and can add resolution notes.
+
+```ts
+await supabase.rpc("owner_update_incident_status", {
+  p_incident_id: "<incident-uuid>",
+  p_status: "resolved",
+  p_resolution_notes: "Plumber replaced the faulty joint.",
+});
+```
+
 ## Read Contract (RLS Protected)
 
 Use normal `select` on:
@@ -92,6 +166,13 @@ Use normal `select` on:
 - `owner_kpis` (view)
 
 RLS decides visibility based on authenticated user ownership/membership.
+
+Schema additions used by the flows:
+- `properties.monthly_rent`, `properties.rooms`, `properties.bathrooms`, `properties.energy_class`, `properties.is_furnished`, `properties.available_from`
+- `leases.security_deposit_amount`
+- `incidents.incident_type`, `incidents.priority`, `incidents.location_details`, `incidents.contact_phone`, `incidents.preferred_visit_date`, `incidents.allow_access_without_presence`, `incidents.resolution_notes`, `incidents.resolved_at`, `incidents.resolved_by`
+- `maintenance_requests.incident_id`
+- `documents.title`, `documents.document_type`
 
 ## Storage Contract
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -159,7 +159,7 @@ Frontend guidance:
 - prefer RPCs for business transitions (status changes, lease creation, payment marking)
 
 Contract source of truth:
-- `backend/BACKEND_CONTRACT.md` (current: `v1.0.0`)
+- `backend/BACKEND_CONTRACT.md` (current: `v1.1.0`)
 
 ## Storage Contract
 

--- a/supabase/migrations/20260220103000_user_flow_alignment.sql
+++ b/supabase/migrations/20260220103000_user_flow_alignment.sql
@@ -1,0 +1,400 @@
+-- Align database schema with tenant/owner user flows (backend only).
+-- This migration keeps naming in English and stays backward compatible.
+
+begin;
+
+-- 1) Add missing enums used by incidents, properties, and documents.
+do $do$
+begin
+  if not exists (
+    select 1
+    from pg_type t
+    join pg_namespace n on n.oid = t.typnamespace
+    where t.typname = 'incident_type'
+      and n.nspname = 'public'
+  ) then
+    create type public.incident_type as enum (
+      'plumbing',
+      'electricity',
+      'appliance',
+      'other'
+    );
+  end if;
+
+  if not exists (
+    select 1
+    from pg_type t
+    join pg_namespace n on n.oid = t.typnamespace
+    where t.typname = 'incident_priority'
+      and n.nspname = 'public'
+  ) then
+    create type public.incident_priority as enum (
+      'low',
+      'medium',
+      'high',
+      'critical'
+    );
+  end if;
+
+  if not exists (
+    select 1
+    from pg_type t
+    join pg_namespace n on n.oid = t.typnamespace
+    where t.typname = 'property_energy_class'
+      and n.nspname = 'public'
+  ) then
+    create type public.property_energy_class as enum (
+      'A',
+      'B',
+      'C',
+      'D',
+      'E',
+      'F',
+      'G'
+    );
+  end if;
+
+  if not exists (
+    select 1
+    from pg_type t
+    join pg_namespace n on n.oid = t.typnamespace
+    where t.typname = 'document_type'
+      and n.nspname = 'public'
+  ) then
+    create type public.document_type as enum (
+      'contract',
+      'inventory',
+      'receipt',
+      'other'
+    );
+  end if;
+end
+$do$;
+
+-- 2) Extend user role to support owner/agency dashboard split.
+alter type public.user_role add value if not exists 'agency';
+
+-- 3) Properties: fields required for search filters and property detail.
+alter table public.properties
+  add column if not exists monthly_rent numeric(10,2),
+  add column if not exists rooms integer,
+  add column if not exists bathrooms integer,
+  add column if not exists energy_class public.property_energy_class,
+  add column if not exists is_furnished boolean not null default false,
+  add column if not exists available_from date;
+
+do $do$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'properties_monthly_rent_non_negative'
+      and conrelid = 'public.properties'::regclass
+  ) then
+    alter table public.properties
+      add constraint properties_monthly_rent_non_negative
+      check (monthly_rent is null or monthly_rent >= 0);
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'properties_rooms_non_negative'
+      and conrelid = 'public.properties'::regclass
+  ) then
+    alter table public.properties
+      add constraint properties_rooms_non_negative
+      check (rooms is null or rooms >= 0);
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'properties_bathrooms_non_negative'
+      and conrelid = 'public.properties'::regclass
+  ) then
+    alter table public.properties
+      add constraint properties_bathrooms_non_negative
+      check (bathrooms is null or bathrooms >= 0);
+  end if;
+end
+$do$;
+
+create index if not exists ix_properties_monthly_rent on public.properties (monthly_rent);
+create index if not exists ix_properties_city_status_rent on public.properties (city, status, monthly_rent);
+create index if not exists ix_properties_available_from on public.properties (available_from);
+
+-- 4) Leases: contract-level field for tenant "My Home / Contract" details.
+alter table public.leases
+  add column if not exists security_deposit_amount numeric(10,2) not null default 0;
+
+do $do$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'leases_security_deposit_non_negative'
+      and conrelid = 'public.leases'::regclass
+  ) then
+    alter table public.leases
+      add constraint leases_security_deposit_non_negative
+      check (security_deposit_amount >= 0);
+  end if;
+end
+$do$;
+
+-- 5) Incidents: type selection, priority, contact data, and resolution tracking.
+alter table public.incidents
+  add column if not exists incident_type public.incident_type not null default 'other',
+  add column if not exists priority public.incident_priority not null default 'medium',
+  add column if not exists location_details text,
+  add column if not exists contact_phone text,
+  add column if not exists preferred_visit_date date,
+  add column if not exists allow_access_without_presence boolean not null default false,
+  add column if not exists resolution_notes text,
+  add column if not exists resolved_at timestamp with time zone,
+  add column if not exists resolved_by uuid;
+
+do $do$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'incidents_resolved_by_fkey'
+      and conrelid = 'public.incidents'::regclass
+  ) then
+    alter table public.incidents
+      add constraint incidents_resolved_by_fkey
+      foreign key (resolved_by)
+      references public.profiles(id)
+      on delete set null;
+  end if;
+end
+$do$;
+
+create index if not exists ix_incidents_type on public.incidents (incident_type);
+create index if not exists ix_incidents_priority on public.incidents (priority);
+create index if not exists ix_incidents_resolved_at on public.incidents (resolved_at);
+
+-- 6) Maintenance follow-up linked to incidents.
+alter table public.maintenance_requests
+  add column if not exists incident_id uuid;
+
+do $do$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'maintenance_requests_incident_id_fkey'
+      and conrelid = 'public.maintenance_requests'::regclass
+  ) then
+    alter table public.maintenance_requests
+      add constraint maintenance_requests_incident_id_fkey
+      foreign key (incident_id)
+      references public.incidents(id)
+      on delete set null;
+  end if;
+end
+$do$;
+
+create index if not exists ix_maintenance_incident_id on public.maintenance_requests (incident_id);
+
+-- 7) Documents: typed category + human-readable title.
+alter table public.documents
+  add column if not exists title text,
+  add column if not exists document_type public.document_type;
+
+update public.documents
+set document_type = case lower(coalesce(doc_type, ''))
+  when 'contract' then 'contract'::public.document_type
+  when 'inventory' then 'inventory'::public.document_type
+  when 'receipt' then 'receipt'::public.document_type
+  else 'other'::public.document_type
+end
+where document_type is null;
+
+alter table public.documents
+  alter column document_type set default 'other';
+
+create index if not exists ix_documents_document_type on public.documents (document_type);
+
+-- 8) RPCs aligned with the incident declaration and resolution flow.
+create or replace function public.create_incident(
+  p_lease_id uuid,
+  p_property_id uuid,
+  p_title text,
+  p_description text,
+  p_incident_type public.incident_type default 'other',
+  p_priority public.incident_priority default 'medium',
+  p_location_details text default null,
+  p_contact_phone text default null,
+  p_preferred_visit_date date default null,
+  p_allow_access_without_presence boolean default false
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $function$
+declare
+  v_id uuid;
+begin
+  if not public.is_lease_tenant(p_lease_id, auth.uid()) then
+    raise exception 'Not allowed';
+  end if;
+
+  insert into public.incidents (
+    property_id,
+    lease_id,
+    reporter_id,
+    title,
+    description,
+    incident_type,
+    priority,
+    location_details,
+    contact_phone,
+    preferred_visit_date,
+    allow_access_without_presence,
+    status
+  )
+  values (
+    p_property_id,
+    p_lease_id,
+    auth.uid(),
+    p_title,
+    p_description,
+    p_incident_type,
+    p_priority,
+    p_location_details,
+    p_contact_phone,
+    p_preferred_visit_date,
+    p_allow_access_without_presence,
+    'open'::public.incident_status
+  )
+  returning id into v_id;
+
+  return v_id;
+end;
+$function$;
+
+create or replace function public.create_incident(
+  p_lease_id uuid,
+  p_property_id uuid,
+  p_title text,
+  p_description text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $function$
+begin
+  return public.create_incident(
+    p_lease_id,
+    p_property_id,
+    p_title,
+    p_description,
+    'other'::public.incident_type,
+    'medium'::public.incident_priority,
+    null,
+    null,
+    null,
+    false
+  );
+end;
+$function$;
+
+create or replace function public.owner_update_incident_status(
+  p_incident_id uuid,
+  p_status text,
+  p_resolution_notes text default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $function$
+declare
+  v_owner uuid;
+  v_next_status public.incident_status;
+begin
+  v_next_status := p_status::public.incident_status;
+
+  select p.owner_id
+    into v_owner
+  from public.incidents i
+  join public.properties p on p.id = i.property_id
+  where i.id = p_incident_id;
+
+  if not found then
+    raise exception 'Incident not found';
+  end if;
+
+  if v_owner <> auth.uid() then
+    raise exception 'Not allowed';
+  end if;
+
+  update public.incidents
+  set
+    status = v_next_status,
+    resolution_notes = case
+      when v_next_status in ('resolved'::public.incident_status, 'closed'::public.incident_status)
+        then coalesce(p_resolution_notes, resolution_notes)
+      else null
+    end,
+    resolved_at = case
+      when v_next_status in ('resolved'::public.incident_status, 'closed'::public.incident_status)
+        then coalesce(resolved_at, now())
+      else null
+    end,
+    resolved_by = case
+      when v_next_status in ('resolved'::public.incident_status, 'closed'::public.incident_status)
+        then auth.uid()
+      else null
+    end
+  where id = p_incident_id;
+end;
+$function$;
+
+create or replace function public.owner_update_incident_status(
+  p_incident_id uuid,
+  p_status text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $function$
+begin
+  perform public.owner_update_incident_status(p_incident_id, p_status, null);
+end;
+$function$;
+
+revoke execute on function public.create_incident(uuid, uuid, text, text) from public;
+revoke execute on function public.create_incident(
+  uuid,
+  uuid,
+  text,
+  text,
+  public.incident_type,
+  public.incident_priority,
+  text,
+  text,
+  date,
+  boolean
+) from public;
+
+grant execute on function public.create_incident(uuid, uuid, text, text) to authenticated, service_role;
+grant execute on function public.create_incident(
+  uuid,
+  uuid,
+  text,
+  text,
+  public.incident_type,
+  public.incident_priority,
+  text,
+  text,
+  date,
+  boolean
+) to authenticated, service_role;
+
+revoke execute on function public.owner_update_incident_status(uuid, text) from public;
+revoke execute on function public.owner_update_incident_status(uuid, text, text) from public;
+grant execute on function public.owner_update_incident_status(uuid, text) to authenticated, service_role;
+grant execute on function public.owner_update_incident_status(uuid, text, text) to authenticated, service_role;
+
+commit;

--- a/supabase/migrations/20260220114500_agency_profiles.sql
+++ b/supabase/migrations/20260220114500_agency_profiles.sql
@@ -1,0 +1,207 @@
+-- Agency legal and business profile data.
+-- Goal: keep frontend integration simple with one dedicated table for agency-only fields.
+
+begin;
+
+create table if not exists public.agency_profiles (
+  profile_id uuid primary key references public.profiles(id) on delete cascade,
+  agency_name text not null,
+  legal_form text,
+  siret text not null,
+  vat_number text,
+  registration_number text,
+  professional_card_number text,
+  guarantee_provider text,
+  guarantee_policy_number text,
+  insurance_provider text,
+  insurance_policy_number text,
+  business_email text,
+  business_phone text,
+  website_url text,
+  address_line1 text,
+  address_line2 text,
+  postal_code text,
+  city text,
+  country text not null default 'FR',
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now()
+);
+
+alter table public.agency_profiles enable row level security;
+
+create unique index if not exists ux_agency_profiles_siret
+  on public.agency_profiles (siret);
+
+do $do$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'agency_profiles_siret_format'
+      and conrelid = 'public.agency_profiles'::regclass
+  ) then
+    alter table public.agency_profiles
+      add constraint agency_profiles_siret_format
+      check (siret ~ '^[0-9]{14}$');
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'agency_profiles_business_email_format'
+      and conrelid = 'public.agency_profiles'::regclass
+  ) then
+    alter table public.agency_profiles
+      add constraint agency_profiles_business_email_format
+      check (
+        business_email is null
+        or business_email ~* '^[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}$'
+      );
+  end if;
+end
+$do$;
+
+create or replace function public.normalize_agency_profile_fields()
+returns trigger
+language plpgsql
+set search_path = public, pg_catalog
+as $function$
+begin
+  if new.siret is not null then
+    new.siret := regexp_replace(new.siret, '\D', '', 'g');
+  end if;
+
+  if new.business_email is not null then
+    new.business_email := lower(trim(new.business_email));
+  end if;
+
+  if new.website_url is not null then
+    new.website_url := trim(new.website_url);
+  end if;
+
+  new.updated_at := now();
+  return new;
+end;
+$function$;
+
+create or replace function public.ensure_agency_profile_role()
+returns trigger
+language plpgsql
+set search_path = public, pg_catalog
+as $function$
+declare
+  v_role public.user_role;
+begin
+  select p.role
+    into v_role
+  from public.profiles p
+  where p.id = new.profile_id;
+
+  if not found then
+    raise exception 'Profile not found';
+  end if;
+
+  if v_role <> 'agency'::public.user_role then
+    raise exception 'Only agency users can write agency_profiles';
+  end if;
+
+  return new;
+end;
+$function$;
+
+drop trigger if exists trg_agency_profiles_normalize on public.agency_profiles;
+create trigger trg_agency_profiles_normalize
+before insert or update on public.agency_profiles
+for each row execute function public.normalize_agency_profile_fields();
+
+drop trigger if exists trg_agency_profiles_role_guard on public.agency_profiles;
+create trigger trg_agency_profiles_role_guard
+before insert or update on public.agency_profiles
+for each row execute function public.ensure_agency_profile_role();
+
+drop policy if exists agency_profiles_select_own on public.agency_profiles;
+create policy agency_profiles_select_own
+on public.agency_profiles
+as permissive
+for select
+to authenticated
+using (profile_id = public.current_user_id());
+
+drop policy if exists agency_profiles_insert_own on public.agency_profiles;
+create policy agency_profiles_insert_own
+on public.agency_profiles
+as permissive
+for insert
+to authenticated
+with check (
+  profile_id = public.current_user_id()
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = agency_profiles.profile_id
+      and p.role = 'agency'::public.user_role
+  )
+);
+
+drop policy if exists agency_profiles_update_own on public.agency_profiles;
+create policy agency_profiles_update_own
+on public.agency_profiles
+as permissive
+for update
+to authenticated
+using (profile_id = public.current_user_id())
+with check (
+  profile_id = public.current_user_id()
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = agency_profiles.profile_id
+      and p.role = 'agency'::public.user_role
+  )
+);
+
+drop policy if exists agency_profiles_delete_own on public.agency_profiles;
+create policy agency_profiles_delete_own
+on public.agency_profiles
+as permissive
+for delete
+to authenticated
+using (profile_id = public.current_user_id());
+
+grant select, insert, update, delete on table public.agency_profiles to authenticated, service_role;
+
+create or replace view public.agency_account as
+select
+  p.id as profile_id,
+  p.role,
+  p.full_name as contact_name,
+  p.phone as contact_phone,
+  p.avatar_url,
+  ap.agency_name,
+  ap.legal_form,
+  ap.siret,
+  ap.vat_number,
+  ap.registration_number,
+  ap.professional_card_number,
+  ap.guarantee_provider,
+  ap.guarantee_policy_number,
+  ap.insurance_provider,
+  ap.insurance_policy_number,
+  ap.business_email,
+  ap.business_phone,
+  ap.website_url,
+  ap.address_line1,
+  ap.address_line2,
+  ap.postal_code,
+  ap.city,
+  ap.country,
+  ap.created_at,
+  ap.updated_at
+from public.profiles p
+left join public.agency_profiles ap on ap.profile_id = p.id
+where p.role = 'agency'::public.user_role;
+
+alter view if exists public.agency_account set (security_invoker = true);
+grant select on public.agency_account to authenticated, service_role;
+
+commit;


### PR DESCRIPTION
## What changed
- Added migration: `supabase/migrations/20260220103000_user_flow_alignment.sql`
  - Added role value: `agency` in `public.user_role`
  - Extended `properties` with search/detail fields:
    - `monthly_rent`, `rooms`, `bathrooms`, `energy_class`, `is_furnished`, `available_from`
  - Extended `leases` with `security_deposit_amount`
  - Extended `incidents` with:
    - `incident_type`, `priority`, `location_details`, `contact_phone`,
      `preferred_visit_date`, `allow_access_without_presence`,
      `resolution_notes`, `resolved_at`, `resolved_by`
  - Linked maintenance to incidents via `maintenance_requests.incident_id`
  - Extended `documents` with `title` and typed `document_type`
  - Updated RPCs with backward-compatible overloads:
    - `create_incident(...)`
    - `owner_update_incident_status(...)`
- Added migration: `supabase/migrations/20260220114500_agency_profiles.sql`
  - New table: `public.agency_profiles` (SIRET/legal/compliance/business fields)
  - Validation and normalization for SIRET/email
  - RLS policies + role guard (only `agency` users can write their own row)
  - New read view: `public.agency_account` for simpler frontend consumption
- Updated backend docs:
  - `backend/BACKEND_CONTRACT.md` (v1.1.0, new agency profile section, new RPC payloads)
  - `backend/README.md` updated contract version reference
- Removed unused checklist doc:
  - `backend/DB_USER_FLOW_CHECKLIST.md`

## Compatibility
- Existing RPC calls remain supported through overloads.
- Changes are additive and designed to be backward compatible.

## Notes for reviewers
- Apply migrations with `supabase db push`.
- Validate agency flow:
  - agency user can upsert own `agency_profiles`
  - non-agency user cannot write agency profile data
  - `agency_account` returns merged profile + agency fields
