### PR TITLE
fix: enable RLS and add security policies for profiles table

### DIFF
--- a/supabase/migrations/20260220170500_fix_profiles_rls.sql
+++ b/supabase/migrations/20260220170500_fix_profiles_rls.sql
@@ -1,0 +1,48 @@
+-- Fix advisory errors on public.profiles:
+-- - Policy Exists RLS Disabled
+-- - RLS Disabled in Public
+
+begin;
+
+alter table if exists public.profiles enable row level security;
+
+do $do$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'profiles'
+      and policyname = 'profiles_select_own'
+  ) then
+    execute $sql$
+      create policy "profiles_select_own"
+      on public.profiles
+      as permissive
+      for select
+      to public
+      using (id = public.current_user_id())
+    $sql$;
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'profiles'
+      and policyname = 'profiles_update_own'
+  ) then
+    execute $sql$
+      create policy "profiles_update_own"
+      on public.profiles
+      as permissive
+      for update
+      to public
+      using (id = public.current_user_id())
+      with check (id = public.current_user_id())
+    $sql$;
+  end if;
+end
+$do$;
+
+commit;


### PR DESCRIPTION
## Summary
This PR fixes Supabase Security Advisor errors on `public.profiles`:
- `Policy Exists RLS Disabled`
- `RLS Disabled in Public`

The table had policies but RLS was disabled remotely.  
This change adds a safe migration to enforce the expected security baseline.

## Changes
- Added migration: `supabase/migrations/20260220170500_fix_profiles_rls.sql`
- Re-enables RLS on `public.profiles`
- Ensures these policies exist (idempotent check before creation):
  - `profiles_select_own`
  - `profiles_update_own`

## Why
`profiles` is exposed through PostgREST and contains user identity data.  
RLS must be enabled so only authorized users can read/update their own profile rows.

## Safety / Compatibility
- Migration is idempotent
- No breaking schema changes
- No API contract changes
- Only hardens/repairs security state

## Validation
After applying migration (`supabase db push`), refresh Supabase Security Advisor:
- Expected: errors on `public.profiles` are resolved.
