### PR TITLE
Feat/supabase owner tenant incident flow

### DIFF
--- a/backend/BACKEND_CONTRACT.md
+++ b/backend/BACKEND_CONTRACT.md
@@ -111,6 +111,26 @@ Returns owner KPI payload.
 await supabase.rpc("get_owner_dashboard");
 ```
 
+### `get_owner_property_tenants`
+
+Returns the owner mapping between properties, leases, and tenant members.
+Use this to list each owner property with corresponding tenants (if any).
+
+```ts
+await supabase.rpc("get_owner_property_tenants", {
+  p_property_id: null, // optional: pass a property UUID to filter
+});
+```
+
+Returned payload includes:
+- `properties_total`, `leases_total`, `tenants_total`
+- `items[]` with:
+  - property fields (`property_id`, `property_title`, `property_address`, `property_city`, `property_status`)
+  - lease fields (`lease_id`, `lease_status`, dates, rent/charges, `payment_day`)
+  - tenant fields (`tenant_id`, `tenant_full_name`, `tenant_phone`, `tenant_share_percent`, `tenant_joined_at`)
+
+When a property has no tenant yet, lease/tenant fields are `null` for that item.
+
 ### Also available
 
 - `apply_to_property`
@@ -118,24 +138,26 @@ await supabase.rpc("get_owner_dashboard");
 - `create_maintenance_request`
 - `owner_update_incident_status`
 
-### `create_incident` (extended)
+### `create_incident` (recommended)
 
-Tenant declares an incident with optional typed metadata.
+Tenant declaration flow can use a simplified call (lease-based, property auto-resolved):
 
 ```ts
 await supabase.rpc("create_incident", {
   p_lease_id: "<lease-uuid>",
-  p_property_id: "<property-uuid>",
-  p_title: "Kitchen leak",
   p_description: "Water leaking under the sink.",
   p_incident_type: "plumbing", // optional, default: "other"
-  p_priority: "medium", // optional, default: "medium"
-  p_location_details: "Floor 1 - Kitchen", // optional
   p_contact_phone: "+33 6 12 34 56 78", // optional
   p_preferred_visit_date: "2026-03-04", // optional
   p_allow_access_without_presence: false, // optional
 });
 ```
+
+Notes:
+- `description` is required.
+- `property_id` is derived from the lease in DB (prevents lease/property mismatch).
+- `title` is auto-generated when not provided.
+- Legacy overloaded signatures are still available for backward compatibility.
 
 ### `owner_update_incident_status` (extended)
 
@@ -162,6 +184,7 @@ Use normal `select` on:
 - `incidents`
 - `maintenance_requests`
 - `documents`
+- `document_users`
 - `profiles`
 - `owner_kpis` (view)
 
@@ -201,6 +224,11 @@ await supabase.storage.from("documents").createSignedUrl(storagePath, 60);
 
 Important:
 - DB row in `public.documents` must stay consistent with `lease_id` and `property_id`.
+- `public.document_users` is auto-maintained to link each document to the concerned users:
+  - owner of the lease/property
+  - tenant members of the lease
+  - uploader
+- Owner/tenant housing relationship is available through `public.get_owner_property_tenants`.
 
 ## Common Frontend Sequence
 

--- a/supabase/migrations/20260220173000_document_user_links.sql
+++ b/supabase/migrations/20260220173000_document_user_links.sql
@@ -1,0 +1,183 @@
+-- Link documents to concerned users (owner and tenant members of the housing lease).
+-- This makes document visibility explicit and easier to consume by clients.
+
+begin;
+
+create table if not exists public.document_users (
+  document_id uuid not null references public.documents(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  link_role text not null check (link_role in ('owner', 'tenant', 'uploader')),
+  created_at timestamp with time zone not null default now(),
+  primary key (document_id, user_id)
+);
+
+alter table public.document_users enable row level security;
+
+create index if not exists ix_document_users_user_id
+  on public.document_users(user_id);
+
+create or replace function public.sync_document_user_links(p_document_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $function$
+declare
+  v_doc public.documents%rowtype;
+begin
+  select *
+    into v_doc
+  from public.documents
+  where id = p_document_id;
+
+  if not found then
+    return;
+  end if;
+
+  -- Rebuild links from source-of-truth document + lease/property membership.
+  delete from public.document_users
+  where document_id = p_document_id;
+
+  -- Owner link (lease owner first, property owner fallback).
+  if v_doc.lease_id is not null then
+    insert into public.document_users (document_id, user_id, link_role)
+    select p_document_id, l.owner_id, 'owner'
+    from public.leases l
+    where l.id = v_doc.lease_id
+    on conflict (document_id, user_id) do nothing;
+  elsif v_doc.property_id is not null then
+    insert into public.document_users (document_id, user_id, link_role)
+    select p_document_id, p.owner_id, 'owner'
+    from public.properties p
+    where p.id = v_doc.property_id
+    on conflict (document_id, user_id) do nothing;
+  end if;
+
+  -- Tenant links from the document lease.
+  if v_doc.lease_id is not null then
+    insert into public.document_users (document_id, user_id, link_role)
+    select p_document_id, lt.tenant_id, 'tenant'
+    from public.lease_tenants lt
+    where lt.lease_id = v_doc.lease_id
+    on conflict (document_id, user_id) do nothing;
+  end if;
+
+  -- Property-level docs (without lease) are also linked to active lease tenants of that property.
+  if v_doc.lease_id is null and v_doc.property_id is not null then
+    insert into public.document_users (document_id, user_id, link_role)
+    select p_document_id, lt.tenant_id, 'tenant'
+    from public.leases l
+    join public.lease_tenants lt on lt.lease_id = l.id
+    where l.property_id = v_doc.property_id
+      and l.status = 'active'::public.lease_status
+    on conflict (document_id, user_id) do nothing;
+  end if;
+
+  -- Keep uploader explicitly linked as well.
+  insert into public.document_users (document_id, user_id, link_role)
+  values (p_document_id, v_doc.uploader_id, 'uploader')
+  on conflict (document_id, user_id) do nothing;
+end;
+$function$;
+
+create or replace function public.trg_documents_sync_user_links()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $function$
+begin
+  perform public.sync_document_user_links(new.id);
+  return new;
+end;
+$function$;
+
+create or replace function public.trg_lease_tenants_sync_document_links()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $function$
+declare
+  v_lease_id uuid;
+  v_property_id uuid;
+  v_doc_id uuid;
+begin
+  v_lease_id := coalesce(new.lease_id, old.lease_id);
+
+  select l.property_id
+    into v_property_id
+  from public.leases l
+  where l.id = v_lease_id;
+
+  for v_doc_id in
+    select d.id
+    from public.documents d
+    where d.lease_id = v_lease_id
+       or (d.lease_id is null and d.property_id = v_property_id)
+  loop
+    perform public.sync_document_user_links(v_doc_id);
+  end loop;
+
+  return coalesce(new, old);
+end;
+$function$;
+
+drop trigger if exists trg_documents_sync_user_links on public.documents;
+create trigger trg_documents_sync_user_links
+after insert or update of lease_id, property_id, uploader_id
+on public.documents
+for each row execute function public.trg_documents_sync_user_links();
+
+drop trigger if exists trg_lease_tenants_sync_document_links on public.lease_tenants;
+create trigger trg_lease_tenants_sync_document_links
+after insert or update or delete
+on public.lease_tenants
+for each row execute function public.trg_lease_tenants_sync_document_links();
+
+-- Backfill existing documents.
+do $do$
+declare
+  r record;
+begin
+  for r in
+    select d.id
+    from public.documents d
+  loop
+    perform public.sync_document_user_links(r.id);
+  end loop;
+end;
+$do$;
+
+drop policy if exists document_users_select_own on public.document_users;
+create policy document_users_select_own
+on public.document_users
+as permissive
+for select
+to authenticated
+using (user_id = public.current_user_id());
+
+-- Keep write access internal (trigger/RPC/service role paths only).
+revoke insert, update, delete on table public.document_users from anon, authenticated;
+grant select on table public.document_users to authenticated;
+grant select, insert, update, delete on table public.document_users to service_role;
+
+-- Make document visibility explicit via linked users.
+drop policy if exists documents_owner_select on public.documents;
+drop policy if exists documents_tenant_select_if_member on public.documents;
+drop policy if exists documents_select_if_linked on public.documents;
+create policy documents_select_if_linked
+on public.documents
+as permissive
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.document_users du
+    where du.document_id = documents.id
+      and du.user_id = public.current_user_id()
+  )
+);
+
+commit;

--- a/supabase/migrations/20260220182500_owner_property_tenant_links.sql
+++ b/supabase/migrations/20260220182500_owner_property_tenant_links.sql
@@ -1,0 +1,114 @@
+-- Owner-facing mapping: properties <-> leases <-> tenant members.
+-- Goal: provide a simple backend read model for dashboards and management screens.
+
+begin;
+
+create or replace function public.get_owner_property_tenants(
+  p_property_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $function$
+declare
+  v_uid uuid := auth.uid();
+begin
+  if v_uid is null then
+    raise exception 'Not allowed';
+  end if;
+
+  if p_property_id is not null and not exists (
+    select 1
+    from public.properties p
+    where p.id = p_property_id
+      and p.owner_id = v_uid
+  ) then
+    raise exception 'Not allowed';
+  end if;
+
+  return (
+    with owner_properties as (
+      select
+        p.id as property_id,
+        p.title as property_title,
+        p.address as property_address,
+        p.city as property_city,
+        p.status as property_status
+      from public.properties p
+      where p.owner_id = v_uid
+        and (p_property_id is null or p.id = p_property_id)
+    ),
+    lease_scope as (
+      select
+        l.id as lease_id,
+        l.property_id,
+        l.status as lease_status,
+        l.start_date,
+        l.end_date,
+        l.rent_amount,
+        l.charges_amount,
+        l.payment_day,
+        l.notice_period_days
+      from public.leases l
+      join owner_properties op on op.property_id = l.property_id
+    ),
+    tenant_scope as (
+      select
+        ls.lease_id,
+        ls.property_id,
+        lt.tenant_id,
+        lt.share_percent,
+        lt.joined_at as tenant_joined_at,
+        pr.full_name as tenant_full_name,
+        pr.phone as tenant_phone,
+        pr.avatar_url as tenant_avatar_url
+      from lease_scope ls
+      join public.lease_tenants lt on lt.lease_id = ls.lease_id
+      left join public.profiles pr on pr.id = lt.tenant_id
+    )
+    select jsonb_build_object(
+      'properties_total', coalesce((select count(*) from owner_properties), 0),
+      'leases_total', coalesce((select count(*) from lease_scope), 0),
+      'tenants_total', coalesce((select count(distinct tenant_id) from tenant_scope), 0),
+      'items', coalesce(
+        (
+          select jsonb_agg(
+            jsonb_build_object(
+              'property_id', op.property_id,
+              'property_title', op.property_title,
+              'property_address', op.property_address,
+              'property_city', op.property_city,
+              'property_status', op.property_status,
+              'lease_id', ls.lease_id,
+              'lease_status', ls.lease_status,
+              'lease_start_date', ls.start_date,
+              'lease_end_date', ls.end_date,
+              'rent_amount', ls.rent_amount,
+              'charges_amount', ls.charges_amount,
+              'payment_day', ls.payment_day,
+              'notice_period_days', ls.notice_period_days,
+              'tenant_id', ts.tenant_id,
+              'tenant_full_name', ts.tenant_full_name,
+              'tenant_share_percent', ts.share_percent,
+              'tenant_joined_at', ts.tenant_joined_at,
+              'tenant_phone', ts.tenant_phone,
+              'tenant_avatar_url', ts.tenant_avatar_url
+            )
+            order by op.property_title, ls.start_date desc
+          )
+          from owner_properties op
+          left join lease_scope ls on ls.property_id = op.property_id
+          left join tenant_scope ts on ts.lease_id = ls.lease_id
+        ),
+        '[]'::jsonb
+      )
+    )
+  );
+end;
+$function$;
+
+revoke execute on function public.get_owner_property_tenants(uuid) from public;
+grant execute on function public.get_owner_property_tenants(uuid) to authenticated, service_role;
+
+commit;

--- a/supabase/migrations/20260220200000_incident_flow_hardening.sql
+++ b/supabase/migrations/20260220200000_incident_flow_hardening.sql
@@ -1,0 +1,267 @@
+-- Incident flow hardening for tenant declaration screens.
+-- Keep schema naming in English and improve frontend integration safety.
+
+begin;
+
+-- 1) Make description mandatory and backfill legacy null/empty rows.
+update public.incidents
+set description = coalesce(
+  nullif(btrim(description), ''),
+  nullif(btrim(title), ''),
+  'Incident reported'
+)
+where description is null
+   or btrim(description) = '';
+
+alter table public.incidents
+  alter column description set not null;
+
+-- 2) Lightweight validation/indexing for tenant dashboard/read flows.
+do $do$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'incidents_contact_phone_length'
+      and conrelid = 'public.incidents'::regclass
+  ) then
+    alter table public.incidents
+      add constraint incidents_contact_phone_length
+      check (
+        contact_phone is null
+        or char_length(btrim(contact_phone)) between 6 and 32
+      );
+  end if;
+end
+$do$;
+
+create index if not exists ix_incidents_reporter_created_at
+  on public.incidents (reporter_id, created_at desc);
+
+-- 3) Title helper so tenant form can submit without explicit title.
+create or replace function public.default_incident_title(
+  p_incident_type public.incident_type,
+  p_description text
+)
+returns text
+language plpgsql
+immutable
+set search_path = public, pg_catalog
+as $function$
+declare
+  v_base text;
+  v_from_description text;
+begin
+  v_base := case p_incident_type
+    when 'plumbing'::public.incident_type then 'Plumbing issue'
+    when 'electricity'::public.incident_type then 'Electrical issue'
+    when 'appliance'::public.incident_type then 'Appliance issue'
+    else 'Other incident'
+  end;
+
+  v_from_description := nullif(btrim(split_part(coalesce(p_description, ''), E'\n', 1)), '');
+
+  if v_from_description is null then
+    return v_base;
+  end if;
+
+  if char_length(v_from_description) > 120 then
+    return left(v_from_description, 117) || '...';
+  end if;
+
+  return v_from_description;
+end;
+$function$;
+
+-- 4) Harden existing RPC (property is derived from lease membership, title can be omitted).
+create or replace function public.create_incident(
+  p_lease_id uuid,
+  p_property_id uuid,
+  p_title text,
+  p_description text,
+  p_incident_type public.incident_type default 'other',
+  p_priority public.incident_priority default 'medium',
+  p_location_details text default null,
+  p_contact_phone text default null,
+  p_preferred_visit_date date default null,
+  p_allow_access_without_presence boolean default false
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $function$
+declare
+  v_id uuid;
+  v_uid uuid := auth.uid();
+  v_property_id uuid;
+  v_title text;
+begin
+  if v_uid is null then
+    raise exception 'Not allowed';
+  end if;
+
+  if nullif(btrim(p_description), '') is null then
+    raise exception 'Description is required';
+  end if;
+
+  if p_preferred_visit_date is not null and p_preferred_visit_date < current_date then
+    raise exception 'Preferred visit date must be today or later';
+  end if;
+
+  select l.property_id
+    into v_property_id
+  from public.leases l
+  join public.lease_tenants lt
+    on lt.lease_id = l.id
+   and lt.tenant_id = v_uid
+  where l.id = p_lease_id;
+
+  if not found then
+    raise exception 'Not allowed';
+  end if;
+
+  if p_property_id is not null and p_property_id <> v_property_id then
+    raise exception 'Lease and property mismatch';
+  end if;
+
+  v_title := coalesce(
+    nullif(btrim(p_title), ''),
+    public.default_incident_title(p_incident_type, p_description)
+  );
+
+  insert into public.incidents (
+    property_id,
+    lease_id,
+    reporter_id,
+    title,
+    description,
+    incident_type,
+    priority,
+    location_details,
+    contact_phone,
+    preferred_visit_date,
+    allow_access_without_presence,
+    status
+  )
+  values (
+    v_property_id,
+    p_lease_id,
+    v_uid,
+    v_title,
+    btrim(p_description),
+    p_incident_type,
+    p_priority,
+    nullif(btrim(p_location_details), ''),
+    nullif(btrim(p_contact_phone), ''),
+    p_preferred_visit_date,
+    p_allow_access_without_presence,
+    'open'::public.incident_status
+  )
+  returning id into v_id;
+
+  return v_id;
+end;
+$function$;
+
+-- 5) Frontend-friendly overloads matching tenant declaration UI.
+create or replace function public.create_incident(
+  p_lease_id uuid,
+  p_description text,
+  p_incident_type public.incident_type default 'other',
+  p_contact_phone text default null,
+  p_preferred_visit_date date default null,
+  p_allow_access_without_presence boolean default false
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $function$
+begin
+  return public.create_incident(
+    p_lease_id,
+    null,
+    null,
+    p_description,
+    p_incident_type,
+    'medium'::public.incident_priority,
+    null,
+    p_contact_phone,
+    p_preferred_visit_date,
+    p_allow_access_without_presence
+  );
+end;
+$function$;
+
+create or replace function public.create_incident(
+  p_lease_id uuid,
+  p_description text
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $function$
+begin
+  return public.create_incident(
+    p_lease_id,
+    p_description,
+    'other'::public.incident_type,
+    null,
+    null,
+    false
+  );
+end;
+$function$;
+
+revoke execute on function public.default_incident_title(public.incident_type, text) from public;
+grant execute on function public.default_incident_title(public.incident_type, text) to authenticated, service_role;
+
+revoke execute on function public.create_incident(uuid, uuid, text, text) from public;
+revoke execute on function public.create_incident(
+  uuid,
+  uuid,
+  text,
+  text,
+  public.incident_type,
+  public.incident_priority,
+  text,
+  text,
+  date,
+  boolean
+) from public;
+revoke execute on function public.create_incident(
+  uuid,
+  text,
+  public.incident_type,
+  text,
+  date,
+  boolean
+) from public;
+revoke execute on function public.create_incident(uuid, text) from public;
+
+grant execute on function public.create_incident(uuid, uuid, text, text) to authenticated, service_role;
+grant execute on function public.create_incident(
+  uuid,
+  uuid,
+  text,
+  text,
+  public.incident_type,
+  public.incident_priority,
+  text,
+  text,
+  date,
+  boolean
+) to authenticated, service_role;
+grant execute on function public.create_incident(
+  uuid,
+  text,
+  public.incident_type,
+  text,
+  date,
+  boolean
+) to authenticated, service_role;
+grant execute on function public.create_incident(uuid, text) to authenticated, service_role;
+
+commit;


### PR DESCRIPTION
## Summary

This PR aligns Supabase backend flows for owner/tenant usage and improves frontend integration safety.

### What’s included

- Added explicit document visibility links:
  - `public.document_users`
  - auto-sync triggers from `documents` and `lease_tenants`
  - `documents` select policy now uses linked users

- Added owner mapping RPC:
  - `public.get_owner_property_tenants(p_property_id uuid default null)`
  - returns owner-scoped `property -> lease -> tenant` data
  - includes practical fields for dashboard usage (`property_address`, `property_city`, `tenant_share_percent`, etc.)

- Hardened incident flow:
  - migration: `20260220200000_incident_flow_hardening.sql`
  - `incidents.description` is now required (with safe backfill)
  - stronger validation for tenant incident creation
  - property is derived from lease membership to avoid mismatch errors
  - added simplified RPC overloads for tenant incident form

- Updated backend contract documentation:
  - `backend/BACKEND_CONTRACT.md`
  - includes new owner/tenant mapping and recommended incident RPC usage

## Why

- Make frontend integration simpler and safer
- Ensure clear and explicit visibility rules for owner/tenant data
- Reduce invalid incident writes and relationship mismatches

## Validation checklist

- [ ] `supabase db push` executed successfully
- [ ] tenant can create incidents with simplified RPC
- [ ] owner can fetch property/tenant mapping via RPC
- [ ] document visibility is correct for linked users
- [ ] unrelated users are blocked by RLS
