### PR TITLE
Feat/supabase tenant active lease owner document form

### DIFF
--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -1,8 +1,8 @@
-SUPABASE_URL=https://rrfcnlxgtshxxzeuhmud.supabase.co/
-SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJyZmNubHhndHNoeHh6ZXVobXVkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzE0Mjc0OTcsImV4cCI6MjA4NzAwMzQ5N30.0wce-BYt8VJcvUDM_gicAcPqI_EFkdC1ahOD-Ypmfkc
+SUPABASE_URL=https://your-staging-project-ref.supabase.co
+SUPABASE_ANON_KEY=<staging-anon-key>
 
-OWNER_EMAIL=owner@imovia.test
-OWNER_PASS=test
+OWNER_EMAIL=<staging-owner-email>
+OWNER_PASS=<staging-owner-password>
 
-TENANT_EMAIL=tenant@imovia.test
-TENANT_PASS=123456
+TENANT_EMAIL=<staging-tenant-email>
+TENANT_PASS=<staging-tenant-password>

--- a/backend/BACKEND_CONTRACT.md
+++ b/backend/BACKEND_CONTRACT.md
@@ -196,7 +196,7 @@ Schema additions used by the flows:
 - `incidents.incident_type`, `incidents.priority`, `incidents.location_details`, `incidents.contact_phone`, `incidents.preferred_visit_date`, `incidents.allow_access_without_presence`, `incidents.resolution_notes`, `incidents.resolved_at`, `incidents.resolved_by`
 - `maintenance_requests.incident_id`
 - `property_tenant_contacts.first_name`, `property_tenant_contacts.last_name`, `property_tenant_contacts.phone`, `property_tenant_contacts.email`, `property_tenant_contacts.tenant_profile_id`
-- `documents.title`, `documents.document_type`
+- `documents.title`, `documents.document_type`, `documents.document_date`, `documents.target_tenant_id`
 
 ## Storage Contract
 
@@ -261,6 +261,7 @@ Never expose:
 
 - This contract assumes migrations in `supabase/migrations/` are applied.
 - Use the same project ref/environment as the branch target for QA.
+- Business rule: a tenant can be affiliated with only one `active` lease/property at a time.
 
 ## Versioning Policy
 

--- a/backend/test.mjs
+++ b/backend/test.mjs
@@ -23,14 +23,25 @@ dotenv.config({ path: envFile });
 
 const url = process.env.SUPABASE_URL;
 const anon = process.env.SUPABASE_ANON_KEY;
-const ownerEmail = process.env.OWNER_EMAIL;
+const ownerEmail = "owner@imovia.test";
 const ownerPass = process.env.OWNER_PASS;
 const tenantEmail = "tenant@imovia.test";
 const tenantPass = process.env.TENANT_PASS;
 
 if (!url || !anon) throw new Error(`Missing SUPABASE_URL or SUPABASE_ANON_KEY in ${envFile}`);
-if (!ownerEmail || !ownerPass) throw new Error(`Missing OWNER_EMAIL/OWNER_PASS in ${envFile}`);
+if (!ownerPass) throw new Error(`Missing OWNER_PASS in ${envFile}`);
 if (!tenantPass) throw new Error(`Missing TENANT_PASS in ${envFile}`);
+
+if (process.env.OWNER_EMAIL && process.env.OWNER_EMAIL.toLowerCase() !== ownerEmail) {
+  console.warn(
+    `Ignoring OWNER_EMAIL=${process.env.OWNER_EMAIL}; this script enforces ${ownerEmail}.`
+  );
+}
+if (process.env.TENANT_EMAIL && process.env.TENANT_EMAIL.toLowerCase() !== tenantEmail) {
+  console.warn(
+    `Ignoring TENANT_EMAIL=${process.env.TENANT_EMAIL}; this script enforces ${tenantEmail}.`
+  );
+}
 
 const testTarget = (process.env.TEST_TARGET || "local").toLowerCase();
 if (!["local", "staging", "prod"].includes(testTarget)) {
@@ -396,6 +407,8 @@ async function run() {
       uploader_id: ownerId,
       storage_path: ownerDocStorage,
       title: `Owner receipt ${runTag}`,
+      document_date: isoDate(0),
+      target_tenant_id: tenantId,
       document_type: "receipt",
       doc_type: "receipt",
     })
@@ -421,13 +434,14 @@ async function run() {
 
   await supabase.auth.signOut();
 
-  // 9) Owner updates incident/maintenance statuses and reads owner views/RPC.
-  console.log("[9/12] Owner updates statuses + reads owner analytics");
+  // 9) Owner updates incident/maintenance statuses and reads owner modules.
+  console.log("[9/12] Owner updates statuses + reads owner modules");
   await login(ownerEmail, ownerPass);
 
   const { error: incidentInProgressErr } = await supabase.rpc("owner_update_incident_status", {
     p_incident_id: incidentA,
     p_status: "in_progress",
+    p_resolution_notes: null,
   });
   if (incidentInProgressErr) throw incidentInProgressErr;
 
@@ -475,6 +489,101 @@ async function run() {
   if (ownerKpisErr) throw ownerKpisErr;
   summary.owner_kpis_count = ownerKpisRows?.length ?? 0;
 
+  const { data: ownerProperties, error: ownerPropertiesErr } = await supabase
+    .from("properties")
+    .select("id, status, address, postal_code, city, property_type, floor_number")
+    .eq("id", property.id);
+  if (ownerPropertiesErr) throw ownerPropertiesErr;
+  assert((ownerProperties || []).length >= 1, "Owner cannot read properties");
+
+  const { data: ownerLeases, error: ownerLeasesErr } = await supabase
+    .from("leases")
+    .select("id, property_id, owner_id, status, start_date, end_date")
+    .eq("id", leaseId);
+  if (ownerLeasesErr) throw ownerLeasesErr;
+  assert((ownerLeases || []).length === 1, "Owner cannot read lease");
+
+  const { data: ownerLeaseMembers, error: ownerLeaseMembersErr } = await supabase
+    .from("lease_tenants")
+    .select("lease_id, tenant_id, joined_at")
+    .eq("lease_id", leaseId);
+  if (ownerLeaseMembersErr) throw ownerLeaseMembersErr;
+  assert((ownerLeaseMembers || []).length >= 1, "Owner cannot read lease_tenants");
+
+  const { data: ownerApplications, error: ownerApplicationsErr } = await supabase
+    .from("rental_applications")
+    .select("id, property_id, tenant_id, owner_id, status")
+    .eq("id", application.id);
+  if (ownerApplicationsErr) throw ownerApplicationsErr;
+  assert((ownerApplications || []).length === 1, "Owner cannot read rental applications");
+
+  const { data: ownerPayments, error: ownerPaymentsErr } = await supabase
+    .from("rent_payments")
+    .select("id, lease_id, status, amount_due, amount_paid, due_date")
+    .eq("lease_id", leaseId);
+  if (ownerPaymentsErr) throw ownerPaymentsErr;
+  assert((ownerPayments || []).length >= 3, "Owner cannot read rent payments");
+
+  const { data: ownerIncidents, error: ownerIncidentsErr } = await supabase
+    .from("incidents")
+    .select("id, lease_id, status, incident_type, priority, description")
+    .in("id", [incidentA, incidentB]);
+  if (ownerIncidentsErr) throw ownerIncidentsErr;
+  assert((ownerIncidents || []).length === 2, "Owner cannot read incidents");
+
+  const { data: ownerMaintenance, error: ownerMaintenanceErr } = await supabase
+    .from("maintenance_requests")
+    .select("id, lease_id, status, title, incident_id, cost_estimated, cost_real")
+    .in("id", [maintenanceA.id, maintenanceB.id]);
+  if (ownerMaintenanceErr) throw ownerMaintenanceErr;
+  assert((ownerMaintenance || []).length === 2, "Owner cannot read maintenance requests");
+
+  const { data: ownerDocuments, error: ownerDocumentsErr } = await supabase
+    .from("documents")
+    .select("id, lease_id, property_id, uploader_id, title, document_type, document_date, target_tenant_id")
+    .in("id", [tenantDoc.id, ownerDoc.id]);
+  if (ownerDocumentsErr) throw ownerDocumentsErr;
+  assert((ownerDocuments || []).length === 2, "Owner cannot read documents");
+  assert(
+    (ownerDocuments || []).some((d) => d.id === ownerDoc.id && d.target_tenant_id === tenantId),
+    "Owner targeted document is missing target_tenant_id"
+  );
+
+  const { data: ownerDocLinks, error: ownerDocLinksErr } = await supabase
+    .from("document_users")
+    .select("document_id, user_id, link_role")
+    .in("document_id", [tenantDoc.id, ownerDoc.id]);
+  if (ownerDocLinksErr) throw ownerDocLinksErr;
+  assert((ownerDocLinks || []).length >= 2, "Owner cannot read document link rows");
+
+  const { data: ownerPropertyImages, error: ownerPropertyImagesErr } = await supabase
+    .from("property_images")
+    .select("id, property_id, storage_path, is_cover")
+    .eq("property_id", property.id);
+  if (ownerPropertyImagesErr) throw ownerPropertyImagesErr;
+  assert((ownerPropertyImages || []).length >= 1, "Owner cannot read property images");
+
+  const { data: ownerPropertyContacts, error: ownerPropertyContactsErr } = await supabase
+    .from("property_tenant_contacts")
+    .select("id, property_id, tenant_profile_id, first_name, last_name, email")
+    .eq("property_id", property.id);
+  if (ownerPropertyContactsErr) throw ownerPropertyContactsErr;
+  assert((ownerPropertyContacts || []).length >= 1, "Owner cannot read property tenant contacts");
+
+  summary.owner_visible_counts = {
+    properties: ownerProperties.length,
+    leases: ownerLeases.length,
+    lease_tenants: ownerLeaseMembers.length,
+    applications: ownerApplications.length,
+    payments: ownerPayments.length,
+    incidents: ownerIncidents.length,
+    maintenance_requests: ownerMaintenance.length,
+    documents: ownerDocuments.length,
+    document_users: ownerDocLinks.length,
+    property_images: ownerPropertyImages.length,
+    property_tenant_contacts: ownerPropertyContacts.length,
+  };
+
   await supabase.auth.signOut();
 
   // 10) Tenant reads all associated data modules.
@@ -487,6 +596,16 @@ async function run() {
     .eq("id", leaseId);
   if (tenantLeasesErr) throw tenantLeasesErr;
   assert((tenantLeases || []).length === 1, "Tenant cannot read own lease");
+
+  const { data: tenantActiveLeases, error: tenantActiveLeasesErr } = await supabase
+    .from("leases")
+    .select("id")
+    .eq("status", "active");
+  if (tenantActiveLeasesErr) throw tenantActiveLeasesErr;
+  assert(
+    (tenantActiveLeases || []).length <= 1,
+    "Rule violation: tenant is affiliated to more than one active housing"
+  );
 
   const { data: tenantLeaseMembership, error: tenantLeaseMembershipErr } = await supabase
     .from("lease_tenants")
@@ -531,7 +650,7 @@ async function run() {
 
   const { data: tenantDocuments, error: tenantDocumentsErr } = await supabase
     .from("documents")
-    .select("id, storage_path, title, document_type, lease_id, property_id")
+    .select("id, storage_path, title, document_type, lease_id, property_id, document_date, target_tenant_id")
     .in("id", [tenantDoc.id, ownerDoc.id]);
   if (tenantDocumentsErr) throw tenantDocumentsErr;
   assert((tenantDocuments || []).length === 2, "Tenant cannot read both linked documents");

--- a/supabase/migrations/20260220230000_single_active_lease_per_tenant.sql
+++ b/supabase/migrations/20260220230000_single_active_lease_per_tenant.sql
@@ -1,0 +1,79 @@
+-- Business rule: one tenant can only have one active affiliated housing at a time.
+-- Enforced at DB level on lease memberships and lease status transitions.
+
+begin;
+
+create or replace function public.enforce_single_active_lease_per_tenant_membership()
+returns trigger
+language plpgsql
+set search_path = public, pg_catalog
+as $function$
+declare
+  v_tenant_id uuid := coalesce(new.tenant_id, old.tenant_id);
+  v_lease_id uuid := coalesce(new.lease_id, old.lease_id);
+  v_target_status public.lease_status;
+begin
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+
+  select l.status
+    into v_target_status
+  from public.leases l
+  where l.id = v_lease_id;
+
+  if v_target_status = 'active'::public.lease_status
+     and exists (
+       select 1
+       from public.lease_tenants lt
+       join public.leases l on l.id = lt.lease_id
+       where lt.tenant_id = v_tenant_id
+         and l.status = 'active'::public.lease_status
+         and lt.lease_id <> v_lease_id
+     ) then
+    raise exception 'A tenant can only be affiliated to one active housing';
+  end if;
+
+  return new;
+end;
+$function$;
+
+create or replace function public.enforce_single_active_lease_per_tenant_status()
+returns trigger
+language plpgsql
+set search_path = public, pg_catalog
+as $function$
+begin
+  if new.status = 'active'::public.lease_status
+     and (tg_op = 'INSERT' or coalesce(old.status, 'draft'::public.lease_status) <> new.status)
+     and exists (
+       select 1
+       from public.lease_tenants this_lt
+       join public.lease_tenants other_lt
+         on other_lt.tenant_id = this_lt.tenant_id
+        and other_lt.lease_id <> this_lt.lease_id
+       join public.leases other_l
+         on other_l.id = other_lt.lease_id
+       where this_lt.lease_id = new.id
+         and other_l.status = 'active'::public.lease_status
+     ) then
+    raise exception 'A tenant can only be affiliated to one active housing';
+  end if;
+
+  return new;
+end;
+$function$;
+
+drop trigger if exists trg_enforce_single_active_lease_membership on public.lease_tenants;
+create trigger trg_enforce_single_active_lease_membership
+before insert or update of lease_id, tenant_id on public.lease_tenants
+for each row
+execute function public.enforce_single_active_lease_per_tenant_membership();
+
+drop trigger if exists trg_enforce_single_active_lease_status on public.leases;
+create trigger trg_enforce_single_active_lease_status
+before insert or update of status on public.leases
+for each row
+execute function public.enforce_single_active_lease_per_tenant_status();
+
+commit;

--- a/supabase/migrations/20260220233000_owner_document_form_alignment.sql
+++ b/supabase/migrations/20260220233000_owner_document_form_alignment.sql
@@ -1,0 +1,175 @@
+-- Align owner "Add document" form with database:
+-- - document_date
+-- - target_tenant_id (optional targeted tenant)
+-- and keep document visibility links consistent.
+
+begin;
+
+alter table public.documents
+  add column if not exists document_date date,
+  add column if not exists target_tenant_id uuid references public.profiles(id) on delete set null;
+
+create index if not exists ix_documents_document_date
+  on public.documents (document_date);
+
+create index if not exists ix_documents_target_tenant_id
+  on public.documents (target_tenant_id);
+
+create or replace function public.validate_document_target_tenant()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $function$
+declare
+  v_ok boolean;
+  v_is_owner boolean;
+begin
+  if new.target_tenant_id is null then
+    return new;
+  end if;
+
+  -- Targeting a specific tenant requires a property scope.
+  if new.property_id is null then
+    raise exception 'target_tenant_id requires property_id';
+  end if;
+
+  -- Only the housing owner can target a specific tenant in owner form flow.
+  v_is_owner := exists (
+    select 1
+    from public.properties p
+    where p.id = new.property_id
+      and p.owner_id = new.uploader_id
+  );
+
+  if not v_is_owner then
+    raise exception 'Only housing owner can set target_tenant_id';
+  end if;
+
+  -- If lease is provided, tenant must belong to that lease.
+  if new.lease_id is not null then
+    v_ok := exists (
+      select 1
+      from public.leases l
+      join public.lease_tenants lt on lt.lease_id = l.id
+      where l.id = new.lease_id
+        and l.property_id = new.property_id
+        and lt.tenant_id = new.target_tenant_id
+    );
+  else
+    -- If no lease is provided, tenant must have an active lease on that property.
+    v_ok := exists (
+      select 1
+      from public.leases l
+      join public.lease_tenants lt on lt.lease_id = l.id
+      where l.property_id = new.property_id
+        and l.status = 'active'::public.lease_status
+        and lt.tenant_id = new.target_tenant_id
+    );
+  end if;
+
+  if not coalesce(v_ok, false) then
+    raise exception 'Target tenant is not affiliated to the selected housing';
+  end if;
+
+  return new;
+end;
+$function$;
+
+drop trigger if exists trg_documents_validate_target_tenant on public.documents;
+create trigger trg_documents_validate_target_tenant
+before insert or update of lease_id, property_id, target_tenant_id, uploader_id
+on public.documents
+for each row execute function public.validate_document_target_tenant();
+
+create or replace function public.sync_document_user_links(p_document_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $function$
+declare
+  v_doc public.documents%rowtype;
+begin
+  select *
+    into v_doc
+  from public.documents
+  where id = p_document_id;
+
+  if not found then
+    return;
+  end if;
+
+  delete from public.document_users
+  where document_id = p_document_id;
+
+  -- Owner link (lease owner first, property owner fallback).
+  if v_doc.lease_id is not null then
+    insert into public.document_users (document_id, user_id, link_role)
+    select p_document_id, l.owner_id, 'owner'
+    from public.leases l
+    where l.id = v_doc.lease_id
+    on conflict (document_id, user_id) do nothing;
+  elsif v_doc.property_id is not null then
+    insert into public.document_users (document_id, user_id, link_role)
+    select p_document_id, p.owner_id, 'owner'
+    from public.properties p
+    where p.id = v_doc.property_id
+    on conflict (document_id, user_id) do nothing;
+  end if;
+
+  -- If owner targeted a specific tenant, link only that tenant.
+  if v_doc.target_tenant_id is not null then
+    insert into public.document_users (document_id, user_id, link_role)
+    values (p_document_id, v_doc.target_tenant_id, 'tenant')
+    on conflict (document_id, user_id) do nothing;
+  else
+    -- Lease-level: all lease tenants.
+    if v_doc.lease_id is not null then
+      insert into public.document_users (document_id, user_id, link_role)
+      select p_document_id, lt.tenant_id, 'tenant'
+      from public.lease_tenants lt
+      where lt.lease_id = v_doc.lease_id
+      on conflict (document_id, user_id) do nothing;
+    end if;
+
+    -- Property-level (without lease): active lease tenants of that property.
+    if v_doc.lease_id is null and v_doc.property_id is not null then
+      insert into public.document_users (document_id, user_id, link_role)
+      select p_document_id, lt.tenant_id, 'tenant'
+      from public.leases l
+      join public.lease_tenants lt on lt.lease_id = l.id
+      where l.property_id = v_doc.property_id
+        and l.status = 'active'::public.lease_status
+      on conflict (document_id, user_id) do nothing;
+    end if;
+  end if;
+
+  -- Uploader always linked.
+  insert into public.document_users (document_id, user_id, link_role)
+  values (p_document_id, v_doc.uploader_id, 'uploader')
+  on conflict (document_id, user_id) do nothing;
+end;
+$function$;
+
+drop trigger if exists trg_documents_sync_user_links on public.documents;
+create trigger trg_documents_sync_user_links
+after insert or update of lease_id, property_id, uploader_id, target_tenant_id
+on public.documents
+for each row execute function public.trg_documents_sync_user_links();
+
+-- Backfill links after sync logic update.
+do $do$
+declare
+  r record;
+begin
+  for r in
+    select d.id
+    from public.documents d
+  loop
+    perform public.sync_document_user_links(r.id);
+  end loop;
+end;
+$do$;
+
+commit;


### PR DESCRIPTION
## Summary

This PR aligns Supabase backend behavior with the current owner/tenant product flows and form requirements.

Main goals:
- enforce tenant affiliation business rules at DB level
- align owner document creation form fields with DB schema
- improve backend seed/test coverage for frontend validation

## What’s included

### 1) Tenant active housing rule (DB enforcement)

- Added migration: `supabase/migrations/20260220230000_single_active_lease_per_tenant.sql`
- Enforces: one tenant can be affiliated to only one **active** housing at a time.
- Implemented with trigger guards on:
  - `public.lease_tenants` (membership inserts/updates)
  - `public.leases` (status changes to `active`)

### 2) Owner document form alignment

- Added migration: `supabase/migrations/20260220233000_owner_document_form_alignment.sql`
- Added new document fields:
  - `documents.document_date`
  - `documents.target_tenant_id` (optional targeted tenant)
- Added validation logic:
  - only housing owner can set `target_tenant_id`
  - targeted tenant must be affiliated to selected housing (lease/property)
- Updated document link sync:
  - if `target_tenant_id` is set, visibility is restricted to that tenant (+ owner/uploader)
  - otherwise existing lease/property-based linking behavior remains

### 3) Test coverage improvements

- Updated `backend/test.mjs`:
  - fixed identities for demo consistency:
    - owner: `owner@imovia.test`
    - tenant: `tenant@imovia.test`
  - expanded owner-side read checks across all major modules
  - verifies tenant can read affiliated property and linked records
  - verifies document targeting behavior (`target_tenant_id`)
  - verifies signed URL access and document linkage

### 4) Backend contract update

- Updated `backend/BACKEND_CONTRACT.md`:
  - documented tenant single-active-housing business rule
  - documented new document fields (`document_date`, `target_tenant_id`)

## Why this PR

- Prevents inconsistent tenancy states directly in the database.
- Makes owner document modal fields fully backed by DB schema and validation.
- Gives frontend developers realistic, end-to-end testable data with strict backend guarantees.

## Validation

- [ ] `supabase db push` applied successfully
- [ ] `node backend/test.mjs` passes on staging
- [ ] owner can create targeted document for a tenant affiliated to selected housing
- [ ] invalid targeted tenant is rejected by DB
- [ ] tenant still sees only authorized records through RLS

## Notes

- This PR is backend-only (Supabase schema, RLS/business guards, integration test script).
- No frontend code changes included.
